### PR TITLE
fixed download url and added a more informative error message

### DIFF
--- a/code/0_get_registry_data.R
+++ b/code/0_get_registry_data.R
@@ -31,7 +31,13 @@ if (
   # 1) check if zip downloaded and otherwise download
   # NOTE: if code-based download fails, manually download: navigate to https://doi.org/10.5281/zenodo.7633995 --> click "Download" by `raw-registries.zip` --> move zip file to `data` directory in this project
   message("Downloading raw registry data...")
-  download.file("https://zenodo.org/record/7633995/files/raw-registries.zip?download=1", zip_raw_reg)
+  tryCatch(
+    download.file("https://zenodo.org/record/7633995/files/raw-registries.zip",
+                  zip_raw_reg),
+    error = \(c) paste0(c$message, " when trying to download file, perhaps retry with a more stable connection?")
+    
+  )
+  
 }
   
   # 2) unzip `raw-registries`


### PR DESCRIPTION
It seems the problem was Windows-specific as I was able to reproduce it myself. When the URL does not end in ".zip" or other archive file (it had the query "?download=1" before) the mode is set wrongly and the download fails, sometimes silently, only for then the unzip to fail.
This could be solved by setting mode="wb", but I am not sure this mode will affect the download on other OSs. The solution I went for was to remove the query, so that the mode is automatically and silently set to "wb" on Windows. I added a tryCatch just in case there were other issues with the `download.file` function.